### PR TITLE
Use `nc -z` to avoid blocking

### DIFF
--- a/clean_kafka.sh
+++ b/clean_kafka.sh
@@ -29,7 +29,7 @@ createTopic ( ) {
 check ( ) {
   PORT=$1
   SERVICE_NAME=$2
-  if [ `nc localhost ${PORT} < /dev/null; echo $?` != 0 ]; then
+  if [ `nc -z localhost ${PORT}; echo $?` != 0 ]; then
     echo "${SERVICE_NAME} not running, start it first with npm run start-kafka"
     exit 1
   fi

--- a/start_kafka.sh
+++ b/start_kafka.sh
@@ -8,7 +8,7 @@ fi
 if [ "$1" = "start" ]; then
   if [ `nc localhost 2181 < /dev/null; echo $?` != 0 ]; then
     sh $KAFKA_HOME/bin/zookeeper-server-start.sh $KAFKA_HOME/config/zookeeper.properties > /dev/null &
-    while [ `nc localhost 2181 < /dev/null; echo $?` != 0 ]; do
+    while [ `nc -z localhost 2181; echo $?` != 0 ]; do
       echo "waiting for Zookeeper..."
       sleep 1 ;
     done
@@ -18,7 +18,7 @@ if [ "$1" = "start" ]; then
 
   if [ `nc localhost 9092 < /dev/null; echo $?` != 0 ]; then
     sh $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties > /dev/null &
-    while [ `nc localhost 9092 < /dev/null; echo $?` != 0 ]; do
+    while [ `nc -z localhost 9092; echo $?` != 0 ]; do
       echo "waiting for Kafka..." ;
       sleep 1 ;
     done


### PR DESCRIPTION
On Debian Sid (where `nc` is from package netcat-traditional, version 1.10-41),
the invocations of `nc` used to determine port availability, hang indefinitely.
I'm not sure why this is, but I believe `-z` exists just for this purpose, and
works for me.